### PR TITLE
Pod typo fix ("loose" for "lose")

### DIFF
--- a/lib/IPC/Cmd.pm
+++ b/lib/IPC/Cmd.pm
@@ -1883,7 +1883,7 @@ special characters are escaped and passed as arguments instead of retaining
 their special meaning.
 
 However, if the command contained arguments that contained whitespace,
-stringifying the command would loose the significance of the whitespace.
+stringifying the command would lose the significance of the whitespace.
 Therefore, C<IPC::Cmd> will quote any arguments containing whitespace in your
 command if the command is passed as an arrayref and contains special characters.
 


### PR DESCRIPTION
Hi there. A small typo fix in the module's pod.
