### PR TITLE
Properly grabs PATH from system

### DIFF
--- a/lib/IPC/Cmd.pm
+++ b/lib/IPC/Cmd.pm
@@ -212,7 +212,6 @@ sub can_run {
         return $command if scalar $syms->getsym( uc $command );
     }
 
-    require Config;
     require File::Spec;
     require ExtUtils::MakeMaker;
 
@@ -223,7 +222,7 @@ sub can_run {
 
     } else {
         for my $dir (
-            (split /\Q$Config::Config{path_sep}\E/, $ENV{PATH}),
+            File::Spec->path,
             File::Spec->curdir
         ) {
             next if ! $dir || ! -d $dir;


### PR DESCRIPTION
Config{path_sep} isn't always set, and is not documented. Additionally, File::Spec includes an OS-agnostic way of grabbing the PATH. There's no reason to use Config here.
