### PR TITLE
Fix a bug in open3_run() signal passing that would clobber $SIG{__{WARN,...

### DIFF
--- a/lib/IPC/Cmd.pm
+++ b/lib/IPC/Cmd.pm
@@ -568,7 +568,8 @@ sub open3_run {
     # it will terminate only after child
     # has terminated (except for SIGKILL,
     # which is specially handled)
-    foreach my $s (keys %SIG) {
+    SIGNAL: foreach my $s (keys %SIG) {
+        next SIGNAL if $s eq '__WARN__' or $s eq '__DIE__'; # Skip and don't clobber __DIE__ & __WARN__
         my $sig_handler;
         $sig_handler = sub {
             kill("$s", $pid);


### PR DESCRIPTION
...DIE}__}

Ever since run_forked() was added in 0.51_01 from a patch from Petya
Kohts via RT #50398 (https://rt.cpan.org/Ticket/Display.html?id=50398)
this code has been clobbering $SIG{**DIE**} and $SIG{**WARN**}, but
_only_ if those had previously been assigned to %SIG.

This makes no sense, as the intent of this code is to pass POSIX
signals to the child, not virtual signals like **DIE** or **WARN**.
