### PR TITLE
move __END__ above POD

### DIFF
--- a/lib/IPC/Cmd.pm
+++ b/lib/IPC/Cmd.pm
@@ -1934,6 +1934,8 @@ sub _pp_child_error {
 
 1;
 
+__END__
+
 =head2 $q = QUOTE
 
 Returns the character used for quoting strings on this platform. This is
@@ -1947,8 +1949,6 @@ You can use it as follows:
 
 This makes sure that C<foo bar> is treated as a string, rather than two
 separate arguments to the C<echo> function.
-
-__END__
 
 =head1 HOW IT WORKS
 


### PR DESCRIPTION
I think this was a mistake at some point when the POD was getting moved around.
