### PR TITLE
fix usage of fcntl(..., F_GETFL, ...)

### DIFF
--- a/lib/IPC/Cmd.pm
+++ b/lib/IPC/Cmd.pm
@@ -845,18 +845,15 @@ sub run_forked {
 
       # prepare sockets to read from child
 
-      $flags = 0;
-      fcntl($child_stdout_socket, POSIX::F_GETFL, $flags) || Carp::confess "can't fnctl F_GETFL: $!";
+      $flags = fcntl($child_stdout_socket, POSIX::F_GETFL, 0) || Carp::confess "can't fnctl F_GETFL: $!";
       $flags |= POSIX::O_NONBLOCK;
       fcntl($child_stdout_socket, POSIX::F_SETFL, $flags) || Carp::confess "can't fnctl F_SETFL: $!";
 
-      $flags = 0;
-      fcntl($child_stderr_socket, POSIX::F_GETFL, $flags) || Carp::confess "can't fnctl F_GETFL: $!";
+      $flags = fcntl($child_stderr_socket, POSIX::F_GETFL, 0) || Carp::confess "can't fnctl F_GETFL: $!";
       $flags |= POSIX::O_NONBLOCK;
       fcntl($child_stderr_socket, POSIX::F_SETFL, $flags) || Carp::confess "can't fnctl F_SETFL: $!";
 
-      $flags = 0;
-      fcntl($child_info_socket, POSIX::F_GETFL, $flags) || Carp::confess "can't fnctl F_GETFL: $!";
+      $flags = fcntl($child_info_socket, POSIX::F_GETFL, 0) || Carp::confess "can't fnctl F_GETFL: $!";
       $flags |= POSIX::O_NONBLOCK;
       fcntl($child_info_socket, POSIX::F_SETFL, $flags) || Carp::confess "can't fnctl F_SETFL: $!";
 


### PR DESCRIPTION
Until about 5 minutes ago (at least in bleadperl), the documentation for fcntl() had included an incorrect example:

    use Fcntl;
    fcntl($filehandle, F_GETFL, $packed_return_buffer)
        or die "can't fcntl F_GETFL: $!";

This is incorect, fcntl() with the FUNCTION set to F_GETFL returns the value, it doesn't store the result in the SCALAR parameter.

Unfortunately this incorrect usage is reflected in IPC::Cmd, this pull request fixes these calls.

This worked despite the incorrect code because F_SETFL ignores most of the possible flags that F_GETFL returns, eg. F_SETFL won't modify F_RDWR.