### PR TITLE
Skip fork tests on macOS too

### DIFF
--- a/t/03_run-forked.t
+++ b/t/03_run-forked.t
@@ -83,7 +83,7 @@ close($fh);
 
 SKIP: {
   skip 'Skip these tests in PERL_CORE', 100 if $ENV{PERL_CORE};
-  skip 'These tests heisenfail on HPUX', 100 if $^O eq 'hpux';
+  skip 'These tests heisenfail on HPUX and macOS', 100 if $^O eq 'hpux' || $^O eq 'darwin';
   for (my $i = 0; $i < 100; $i++) {
     my $f_ipc_cmd = IPC::Cmd::run_forked("$cat $filename");
     my $f_backticks = `$cat $filename`;


### PR DESCRIPTION
Hello BINGOS , I have been encountering the same error Dave patched for when installing on macOS. I became aware of it when releasing a new module that indirectly depends on this one, and saw CPAN Testers failures (for another issue). I installed a few Perl versions and tried installing my module, and ran into this error several times with different Perl versions. (FWIW this error causes Module::Build's installation to fail.) Thanks!